### PR TITLE
fix: Change canvas positioning to absolute to fix UI overlay issue

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -42,12 +42,14 @@
 
 /* Canvas and background */
 .graph-network-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     background-color: var(--bg-secondary);
     border-radius: 12px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    position: relative;
     transition: background-color 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary

- Changed `.graph-network-canvas` from `position: relative` to `position: absolute`
- Added `top: 0` and `left: 0` to properly position the canvas
- This removes the canvas from document flow, allowing UI overlays to position correctly on top

## Problem

The graph canvas was using `position: relative`, which kept it in the document flow. Combined with `height: 100%`, this caused the canvas to push absolutely-positioned UI elements (controls, legend, settings panel) below the graph instead of allowing them to overlay on top of it.

## Solution

By changing to `position: absolute`, the canvas is removed from the normal document flow and serves as a proper background layer for the absolutely-positioned UI overlays.

## Testing

- ✅ Built successfully
- ✅ Tested with examples
- ✅ UI elements now properly overlay on the canvas

## Closes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)