### PR TITLE
feat: Add npm Dependency Explorer demo + fix highlighting

### DIFF
--- a/docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md
+++ b/docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md
@@ -1,0 +1,48 @@
+---
+date: 2026-03-27
+topic: npm-dependency-demo
+---
+
+# npm Dependency Explorer Demo
+
+## Problem Frame
+The library has two demos (basic and diplomatic networks) but neither showcases a real-world use case that developers immediately relate to. An npm dependency graph demo would resonate with every JS developer, demonstrate the library's full feature set in a coherent scenario, and serve as a compelling "look what you can build" showcase.
+
+## Requirements
+
+- R1. Create a new demo page (`docs/examples/dependency-graph.html` + `dependency-graph.js`) that visualizes an npm-style dependency graph
+- R2. Curate a hardcoded dataset of ~30-50 nodes modeled loosely after a real package ecosystem (e.g., Express-like), with realistic package names and dependency relationships
+- R3. Nodes must be typed as `direct`, `dev`, and `transitive` dependencies, each with a distinct shape and auto-color grouping
+- R4. All edges must be directed (dependencies flow from dependent → dependency)
+- R5. **Path tracing:** Clicking any transitive dependency highlights the full dependency chain back to the root package using `highlightPath()` with animation
+- R6. **Vulnerability overlay:** A toggle button recolors nodes by security status (safe/warning/critical) and highlights compromised dependency chains. At least 2-3 packages should be marked as "vulnerable" with their upstream chains shown as attack paths
+- R7. **Depth filtering:** Double-clicking any package filters to its dependency neighborhood with breadcrumb navigation back to the full graph
+- R8. Demo must include a brief instruction panel or tooltip explaining the three interactive features so first-time visitors know what to try
+- R9. Demo should work with both light and dark themes (theme toggle already provided by the library)
+
+## Success Criteria
+- A developer visiting the demo page immediately understands what the library can do
+- All three interactive features (path tracing, vulnerability overlay, depth filtering) work without bugs
+- The demo loads instantly (no external API calls) and the physics settle into a readable layout within 2-3 seconds
+- The curated data produces a visually balanced graph — not too sparse, not too cluttered
+
+## Scope Boundaries
+- No live npm registry API calls — data is fully curated and hardcoded
+- No "paste your package.json" functionality
+- No actual vulnerability scanning — security statuses are hand-assigned for visual impact
+- No new library features required — demo uses only existing public API
+
+## Key Decisions
+- **Curated over live data:** Ensures instant load, no API dependency, and full control over visual presentation
+- **Express-like ecosystem:** Familiar to most JS developers, has a rich dependency tree with interesting structure
+- **Three feature showcases:** Path tracing, vulnerability overlay, and depth filtering were chosen as the highest-impact visual demonstrations of the library's capabilities
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R2][Needs research] Exact package names and dependency structure to use — should be realistic but doesn't need to exactly match any real package
+- [Affects R6][Technical] How to implement the vulnerability toggle — likely via `setData()` to update node colors/styles, or potentially a custom overlay approach
+- [Affects R8][Technical] Best UI pattern for the instruction panel — floating overlay, sidebar, or inline hints
+
+## Next Steps
+→ `/ce:plan` for structured implementation planning

--- a/docs/examples/advanced.js
+++ b/docs/examples/advanced.js
@@ -562,8 +562,8 @@ async function initializeGraph() {
             showTitle: true,
             showBreadcrumbs: true,
             damping: 0.95,
-            repulsionStrength: 6500,
-            attractionStrength: 0.001,
+            repulsionStrength: 10000,
+            attractionStrength: 0.0004,
             filterDepth: 1
         }
     });

--- a/docs/examples/npm-explorer.html
+++ b/docs/examples/npm-explorer.html
@@ -1,0 +1,482 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=yes, viewport-fit=cover"
+        />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <title>svgnet — npm Dependency Explorer</title>
+        <link rel="stylesheet" href="../assets/svgnet.css" />
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+                background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+                min-height: 100vh;
+                color: #e0e0e0;
+            }
+
+            .header {
+                background: rgba(15, 15, 30, 0.95);
+                backdrop-filter: blur(10px);
+                border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+                padding: 1rem 2rem;
+                position: sticky;
+                top: 0;
+                z-index: 100;
+            }
+
+            .header h1 {
+                color: #e0e0e0;
+                font-size: 1.8rem;
+                font-weight: 600;
+                margin-bottom: 0.25rem;
+            }
+
+            .header h1 span {
+                color: #cb3837;
+            }
+
+            .header p {
+                color: #888;
+                font-size: 0.9rem;
+            }
+
+            .container {
+                display: flex;
+                height: calc(100vh - 70px);
+            }
+
+            .sidebar {
+                width: 280px;
+                background: rgba(15, 15, 30, 0.95);
+                backdrop-filter: blur(10px);
+                border-right: 1px solid rgba(255, 255, 255, 0.1);
+                padding: 1.25rem;
+                overflow-y: auto;
+                flex-shrink: 0;
+            }
+
+            .main-content {
+                flex: 1;
+                position: relative;
+            }
+
+            #graph-container {
+                width: 100%;
+                height: 100%;
+                background: #1a1a2e;
+            }
+
+            .section {
+                margin-bottom: 1.5rem;
+            }
+
+            .section h3 {
+                font-size: 0.85rem;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: 0.5px;
+                margin-bottom: 0.75rem;
+                color: #888;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+                padding-bottom: 0.5rem;
+            }
+
+            .stats-grid {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 0.5rem;
+            }
+
+            .stat {
+                background: rgba(255, 255, 255, 0.05);
+                border-radius: 6px;
+                padding: 0.6rem;
+                text-align: center;
+            }
+
+            .stat-value {
+                font-size: 1.3rem;
+                font-weight: 700;
+                color: #fff;
+            }
+
+            .stat-label {
+                font-size: 0.65rem;
+                text-transform: uppercase;
+                letter-spacing: 0.5px;
+                color: #888;
+                margin-top: 0.15rem;
+            }
+
+            .btn {
+                display: block;
+                width: 100%;
+                padding: 0.6rem 1rem;
+                border: none;
+                border-radius: 6px;
+                font-size: 0.85rem;
+                cursor: pointer;
+                transition: all 0.2s;
+                font-weight: 500;
+                margin-bottom: 0.5rem;
+                text-align: center;
+            }
+
+            .btn-vuln {
+                background: rgba(239, 68, 68, 0.15);
+                color: #ef4444;
+                border: 1px solid rgba(239, 68, 68, 0.3);
+            }
+
+            .btn-vuln:hover {
+                background: rgba(239, 68, 68, 0.25);
+            }
+
+            .btn-vuln.active {
+                background: rgba(239, 68, 68, 0.4);
+                border-color: #ef4444;
+                color: #fff;
+            }
+
+            .btn-reset {
+                background: rgba(255, 255, 255, 0.08);
+                color: #ccc;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+            }
+
+            .btn-reset:hover {
+                background: rgba(255, 255, 255, 0.15);
+            }
+
+            .legend-item {
+                display: flex;
+                align-items: center;
+                margin-bottom: 0.4rem;
+                font-size: 0.8rem;
+                color: #ccc;
+            }
+
+            .legend-shape {
+                width: 14px;
+                height: 14px;
+                margin-right: 0.6rem;
+                flex-shrink: 0;
+            }
+
+            .legend-circle {
+                border-radius: 50%;
+            }
+
+            .legend-rect {
+                border-radius: 2px;
+            }
+
+            .legend-triangle {
+                width: 0;
+                height: 0;
+                border-left: 7px solid transparent;
+                border-right: 7px solid transparent;
+                border-bottom: 14px solid;
+                background: none !important;
+            }
+
+            .node-info {
+                position: absolute;
+                top: 1rem;
+                right: 1rem;
+                background: rgba(15, 15, 30, 0.95);
+                backdrop-filter: blur(10px);
+                border-radius: 10px;
+                padding: 1rem;
+                box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                max-width: 280px;
+                display: none;
+                z-index: 10;
+            }
+
+            .node-info h4 {
+                margin-bottom: 0.4rem;
+                color: #fff;
+                font-size: 1rem;
+            }
+
+            .node-info-type {
+                font-size: 0.75rem;
+                color: #888;
+                margin-bottom: 0.5rem;
+            }
+
+            .node-info-vuln {
+                font-size: 0.8rem;
+                padding: 0.3rem 0.6rem;
+                border-radius: 4px;
+                margin-top: 0.5rem;
+                display: none;
+            }
+
+            .vuln-critical {
+                background: rgba(239, 68, 68, 0.2);
+                color: #ef4444;
+                border: 1px solid rgba(239, 68, 68, 0.3);
+            }
+
+            .vuln-warning {
+                background: rgba(245, 158, 11, 0.2);
+                color: #f59e0b;
+                border: 1px solid rgba(245, 158, 11, 0.3);
+            }
+
+            .instruction-overlay {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+                background: rgba(15, 15, 30, 0.97);
+                backdrop-filter: blur(20px);
+                border-radius: 16px;
+                padding: 2rem;
+                max-width: 420px;
+                z-index: 50;
+                border: 1px solid rgba(255, 255, 255, 0.15);
+                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+            }
+
+            .instruction-overlay h3 {
+                color: #fff;
+                font-size: 1.2rem;
+                margin-bottom: 1.25rem;
+                text-align: center;
+            }
+
+            .instruction-item {
+                display: flex;
+                align-items: flex-start;
+                margin-bottom: 1rem;
+                gap: 0.75rem;
+            }
+
+            .instruction-icon {
+                font-size: 1.4rem;
+                flex-shrink: 0;
+                width: 28px;
+                text-align: center;
+            }
+
+            .instruction-text {
+                font-size: 0.85rem;
+                color: #ccc;
+                line-height: 1.4;
+            }
+
+            .instruction-text strong {
+                color: #fff;
+                display: block;
+                margin-bottom: 0.15rem;
+            }
+
+            .btn-dismiss {
+                display: block;
+                width: 100%;
+                margin-top: 1.25rem;
+                padding: 0.7rem;
+                background: rgba(255, 255, 255, 0.1);
+                border: 1px solid rgba(255, 255, 255, 0.2);
+                border-radius: 8px;
+                color: #fff;
+                font-size: 0.9rem;
+                cursor: pointer;
+                transition: background 0.2s;
+            }
+
+            .btn-dismiss:hover {
+                background: rgba(255, 255, 255, 0.2);
+            }
+
+            .status-bar {
+                position: absolute;
+                bottom: 1rem;
+                left: 50%;
+                transform: translateX(-50%);
+                background: rgba(15, 15, 30, 0.9);
+                backdrop-filter: blur(10px);
+                border-radius: 8px;
+                padding: 0.5rem 1rem;
+                font-size: 0.8rem;
+                color: #888;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                display: none;
+                z-index: 10;
+                white-space: nowrap;
+            }
+
+            @media (max-width: 768px) {
+                .container {
+                    flex-direction: column;
+                }
+
+                .sidebar {
+                    width: 100%;
+                    height: auto;
+                    max-height: 35vh;
+                }
+
+                .main-content {
+                    height: 65vh;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div class="header">
+            <h1><span>npm</span> Dependency Explorer</h1>
+            <p>Interactive visualization of package dependencies — built with svgnet</p>
+        </div>
+
+        <div class="container">
+            <div class="sidebar">
+                <div class="section">
+                    <h3>Package Stats</h3>
+                    <div class="stats-grid">
+                        <div class="stat">
+                            <div class="stat-value" id="stat-total">0</div>
+                            <div class="stat-label">Packages</div>
+                        </div>
+                        <div class="stat">
+                            <div class="stat-value" id="stat-direct">0</div>
+                            <div class="stat-label">Direct</div>
+                        </div>
+                        <div class="stat">
+                            <div class="stat-value" id="stat-dev">0</div>
+                            <div class="stat-label">Dev</div>
+                        </div>
+                        <div class="stat">
+                            <div class="stat-value" id="stat-transitive">0</div>
+                            <div class="stat-label">Transitive</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section">
+                    <h3>Security</h3>
+                    <button class="btn btn-vuln" id="vuln-toggle" onclick="toggleVulnerabilities()">
+                        Show Vulnerabilities
+                    </button>
+                </div>
+
+                <div class="section">
+                    <h3>Controls</h3>
+                    <button class="btn btn-reset" onclick="clearAllHighlights()">
+                        Clear Highlights
+                    </button>
+                    <button class="btn btn-reset" onclick="graph.resetViewAndLayout()">
+                        Reset Layout
+                    </button>
+                </div>
+
+                <div class="section">
+                    <h3>Legend</h3>
+                    <div class="legend-item">
+                        <div
+                            class="legend-shape legend-circle"
+                            style="background: #8b5cf6; width: 18px; height: 18px"
+                        ></div>
+                        <span>Root package</span>
+                    </div>
+                    <div class="legend-item">
+                        <div class="legend-shape legend-rect" style="background: #3b82f6"></div>
+                        <span>Direct dependency</span>
+                    </div>
+                    <div class="legend-item">
+                        <div
+                            class="legend-shape legend-triangle"
+                            style="border-bottom-color: #f59e0b"
+                        ></div>
+                        <span>Dev dependency</span>
+                    </div>
+                    <div class="legend-item">
+                        <div class="legend-shape legend-circle" style="background: #6b7280"></div>
+                        <span>Transitive dependency</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="main-content">
+                <div id="graph-container"></div>
+
+                <div class="node-info" id="node-info">
+                    <h4 id="info-name">-</h4>
+                    <div class="node-info-type" id="info-type">-</div>
+                    <div class="node-info-vuln" id="info-vuln"></div>
+                </div>
+
+                <div class="status-bar" id="status-bar"></div>
+
+                <div class="instruction-overlay" id="instructions">
+                    <h3>How to Explore</h3>
+                    <div class="instruction-item">
+                        <div class="instruction-icon">&#x1F517;</div>
+                        <div class="instruction-text">
+                            <strong>Trace dependency chains</strong>
+                            Click any package to highlight the path from root to that dependency.
+                        </div>
+                    </div>
+                    <div class="instruction-item">
+                        <div class="instruction-icon">&#x1F6E1;</div>
+                        <div class="instruction-text">
+                            <strong>Reveal vulnerabilities</strong>
+                            Toggle "Show Vulnerabilities" to see security risks and compromised
+                            dependency chains.
+                        </div>
+                    </div>
+                    <div class="instruction-item">
+                        <div class="instruction-icon">&#x1F50D;</div>
+                        <div class="instruction-text">
+                            <strong>Focus on a package</strong>
+                            Double-click any node to filter to its neighborhood. Use breadcrumbs to
+                            navigate back.
+                        </div>
+                    </div>
+                    <button class="btn-dismiss" onclick="dismissInstructions()">Got it</button>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            (function () {
+                const script = document.createElement('script');
+                if (
+                    window.location.hostname === 'localhost' ||
+                    window.location.hostname === '127.0.0.1'
+                ) {
+                    script.src = '/svgnet.js';
+                } else {
+                    script.src = '../assets/svgnet.js';
+                }
+                script.onload = function () {
+                    console.log('SVGNet script loaded successfully');
+                    setTimeout(function () {
+                        if (window.initializeWhenReady) {
+                            window.initializeWhenReady();
+                        }
+                    }, 10);
+                };
+                script.onerror = function () {
+                    console.error('Failed to load SVGNet script from:', script.src);
+                };
+                document.head.appendChild(script);
+            })();
+        </script>
+        <script src="npm-explorer.js"></script>
+    </body>
+</html>

--- a/docs/examples/npm-explorer.html
+++ b/docs/examples/npm-explorer.html
@@ -370,7 +370,7 @@
                 <div class="section">
                     <h3>Security</h3>
                     <button class="btn btn-vuln" id="vuln-toggle" onclick="toggleVulnerabilities()">
-                        Show Vulnerabilities
+                        Show Known CVEs
                     </button>
                 </div>
 
@@ -435,8 +435,8 @@
                         <div class="instruction-icon">&#x1F6E1;</div>
                         <div class="instruction-text">
                             <strong>Reveal vulnerabilities</strong>
-                            Toggle "Show Vulnerabilities" to see security risks and compromised
-                            dependency chains.
+                            Toggle "Show Known CVEs" to highlight packages with historical
+                            vulnerabilities and their dependency chains.
                         </div>
                     </div>
                     <div class="instruction-item">

--- a/docs/examples/npm-explorer.js
+++ b/docs/examples/npm-explorer.js
@@ -1,0 +1,426 @@
+// npm Dependency Explorer — showcases SVGNet with a real-world use case
+// No imports needed — the library is loaded via script tag as window.SVGNet
+
+let graph;
+let vulnMode = false;
+const ROOT_ID = 'my-app';
+
+// --- Curated Dataset ---
+
+const VULN_DATA = {
+    qs: { severity: 'critical', advisory: 'Prototype pollution in qs before 6.10.3' },
+    debug: { severity: 'warning', advisory: 'Regular expression DoS in debug <3.1.0' },
+    minimist: { severity: 'critical', advisory: 'Prototype pollution in minimist <1.2.6' }
+};
+
+function buildDataset() {
+    const nodes = [
+        // Root
+        { id: 'my-app', name: 'my-app', type: 'root', shape: 'circle', size: 55 },
+
+        // Direct dependencies
+        { id: 'express', name: 'express', type: 'direct', shape: 'rectangle', size: 40 },
+        { id: 'lodash', name: 'lodash', type: 'direct', shape: 'rectangle', size: 35 },
+        { id: 'axios', name: 'axios', type: 'direct', shape: 'rectangle', size: 35 },
+        { id: 'mongoose', name: 'mongoose', type: 'direct', shape: 'rectangle', size: 38 },
+        { id: 'dotenv', name: 'dotenv', type: 'direct', shape: 'rectangle', size: 25 },
+        { id: 'cors', name: 'cors', type: 'direct', shape: 'rectangle', size: 25 },
+        { id: 'jsonwebtoken', name: 'jsonwebtoken', type: 'direct', shape: 'rectangle', size: 32 },
+        { id: 'bcrypt', name: 'bcrypt', type: 'direct', shape: 'rectangle', size: 28 },
+
+        // Dev dependencies
+        { id: 'jest', name: 'jest', type: 'dev', shape: 'triangle', size: 30 },
+        { id: 'eslint', name: 'eslint', type: 'dev', shape: 'triangle', size: 28 },
+        { id: 'prettier', name: 'prettier', type: 'dev', shape: 'triangle', size: 25 },
+        { id: 'nodemon', name: 'nodemon', type: 'dev', shape: 'triangle', size: 25 },
+        { id: 'supertest', name: 'supertest', type: 'dev', shape: 'triangle', size: 25 },
+
+        // Transitive — express tree
+        { id: 'body-parser', name: 'body-parser', type: 'transitive', shape: 'circle', size: 22 },
+        {
+            id: 'cookie-parser',
+            name: 'cookie-parser',
+            type: 'transitive',
+            shape: 'circle',
+            size: 18
+        },
+        { id: 'qs', name: 'qs', type: 'transitive', shape: 'circle', size: 20 },
+        { id: 'debug', name: 'debug', type: 'transitive', shape: 'circle', size: 20 },
+        { id: 'mime', name: 'mime', type: 'transitive', shape: 'circle', size: 16 },
+        { id: 'send', name: 'send', type: 'transitive', shape: 'circle', size: 18 },
+        { id: 'serve-static', name: 'serve-static', type: 'transitive', shape: 'circle', size: 18 },
+        { id: 'accepts', name: 'accepts', type: 'transitive', shape: 'circle', size: 16 },
+        { id: 'content-type', name: 'content-type', type: 'transitive', shape: 'circle', size: 14 },
+        { id: 'on-finished', name: 'on-finished', type: 'transitive', shape: 'circle', size: 14 },
+
+        // Transitive — axios tree
+        {
+            id: 'follow-redirects',
+            name: 'follow-redirects',
+            type: 'transitive',
+            shape: 'circle',
+            size: 18
+        },
+        { id: 'form-data', name: 'form-data', type: 'transitive', shape: 'circle', size: 16 },
+
+        // Transitive — mongoose tree
+        { id: 'bson', name: 'bson', type: 'transitive', shape: 'circle', size: 18 },
+        { id: 'mongodb', name: 'mongodb', type: 'transitive', shape: 'circle', size: 22 },
+        { id: 'kareem', name: 'kareem', type: 'transitive', shape: 'circle', size: 16 },
+        { id: 'mpath', name: 'mpath', type: 'transitive', shape: 'circle', size: 14 },
+
+        // Transitive — jsonwebtoken tree
+        { id: 'jws', name: 'jws', type: 'transitive', shape: 'circle', size: 16 },
+        { id: 'jwa', name: 'jwa', type: 'transitive', shape: 'circle', size: 14 },
+
+        // Transitive — jest tree
+        { id: 'jest-cli', name: 'jest-cli', type: 'transitive', shape: 'circle', size: 18 },
+        { id: 'babel-jest', name: 'babel-jest', type: 'transitive', shape: 'circle', size: 16 },
+
+        // Transitive — shared/deep
+        { id: 'ms', name: 'ms', type: 'transitive', shape: 'circle', size: 14 },
+        { id: 'minimist', name: 'minimist', type: 'transitive', shape: 'circle', size: 16 },
+        { id: 'safe-buffer', name: 'safe-buffer', type: 'transitive', shape: 'circle', size: 14 },
+        { id: 'inherits', name: 'inherits', type: 'transitive', shape: 'circle', size: 12 }
+    ];
+
+    const links = [
+        // Root → direct
+        { source: 'my-app', target: 'express' },
+        { source: 'my-app', target: 'lodash' },
+        { source: 'my-app', target: 'axios' },
+        { source: 'my-app', target: 'mongoose' },
+        { source: 'my-app', target: 'dotenv' },
+        { source: 'my-app', target: 'cors' },
+        { source: 'my-app', target: 'jsonwebtoken' },
+        { source: 'my-app', target: 'bcrypt' },
+
+        // Root → dev
+        { source: 'my-app', target: 'jest' },
+        { source: 'my-app', target: 'eslint' },
+        { source: 'my-app', target: 'prettier' },
+        { source: 'my-app', target: 'nodemon' },
+        { source: 'my-app', target: 'supertest' },
+
+        // express → transitive
+        { source: 'express', target: 'body-parser' },
+        { source: 'express', target: 'cookie-parser' },
+        { source: 'express', target: 'debug' },
+        { source: 'express', target: 'send' },
+        { source: 'express', target: 'serve-static' },
+        { source: 'express', target: 'accepts' },
+        { source: 'express', target: 'content-type' },
+        { source: 'express', target: 'on-finished' },
+        { source: 'express', target: 'qs' },
+
+        // body-parser → qs (vulnerability chain)
+        { source: 'body-parser', target: 'qs' },
+        { source: 'body-parser', target: 'content-type' },
+        { source: 'body-parser', target: 'on-finished' },
+
+        // send → mime
+        { source: 'send', target: 'mime' },
+        { source: 'send', target: 'debug' },
+        { source: 'send', target: 'ms' },
+        { source: 'send', target: 'on-finished' },
+
+        // serve-static → send
+        { source: 'serve-static', target: 'send' },
+
+        // debug → ms
+        { source: 'debug', target: 'ms' },
+
+        // axios → transitive
+        { source: 'axios', target: 'follow-redirects' },
+        { source: 'axios', target: 'form-data' },
+
+        // mongoose → transitive
+        { source: 'mongoose', target: 'mongodb' },
+        { source: 'mongoose', target: 'kareem' },
+        { source: 'mongoose', target: 'mpath' },
+        { source: 'mongodb', target: 'bson' },
+        { source: 'mongodb', target: 'safe-buffer' },
+
+        // jsonwebtoken → transitive
+        { source: 'jsonwebtoken', target: 'jws' },
+        { source: 'jws', target: 'jwa' },
+        { source: 'jws', target: 'safe-buffer' },
+
+        // bcrypt → transitive
+        { source: 'bcrypt', target: 'inherits' },
+
+        // jest → transitive
+        { source: 'jest', target: 'jest-cli' },
+        { source: 'jest-cli', target: 'babel-jest' },
+
+        // eslint/nodemon → minimist (vulnerability chain)
+        { source: 'eslint', target: 'minimist' },
+        { source: 'nodemon', target: 'minimist' },
+
+        // cors → inherits
+        { source: 'cors', target: 'inherits' },
+
+        // form-data → safe-buffer
+        { source: 'form-data', target: 'safe-buffer' }
+    ];
+
+    return { nodes, links };
+}
+
+// --- Initialization ---
+
+function initializeWhenReady() {
+    if (typeof SVGNet !== 'undefined') {
+        initializeGraph();
+    } else {
+        setTimeout(initializeWhenReady, 100);
+    }
+}
+
+async function initializeGraph() {
+    // HMR cleanup
+    if (window.graph) {
+        try {
+            await window.graph.clearData({ animate: true, duration: 300 });
+            window.graph.destroy();
+        } catch (e) {
+            console.log('Previous graph cleanup skipped:', e.message);
+        }
+    }
+
+    const dataset = buildDataset();
+
+    graph = new SVGNet('graph-container', {
+        data: dataset,
+        config: {
+            title: '',
+            theme: 'dark',
+            showControls: true,
+            showLegend: false,
+            showBreadcrumbs: true,
+            defaultDirected: true,
+            filterDepth: 2,
+            repulsionStrength: 8000,
+            attractionStrength: 0.0008,
+            damping: 0.92,
+            groupingStrength: 0.002
+        }
+    });
+    window.graph = graph;
+
+    // Custom type colors
+    graph.setNodeTypeStyle('root', { fill: '#8b5cf6', stroke: '#7c3aed', strokeWidth: 3 });
+    graph.setNodeTypeStyle('direct', { fill: '#3b82f6', stroke: '#2563eb', strokeWidth: 2 });
+    graph.setNodeTypeStyle('dev', { fill: '#f59e0b', stroke: '#d97706', strokeWidth: 2 });
+    graph.setNodeTypeStyle('transitive', { fill: '#6b7280', stroke: '#4b5563', strokeWidth: 1 });
+
+    // Update stats
+    const counts = { root: 0, direct: 0, dev: 0, transitive: 0 };
+    dataset.nodes.forEach(n => counts[n.type]++);
+    document.getElementById('stat-total').textContent = dataset.nodes.length;
+    document.getElementById('stat-direct').textContent = counts.direct;
+    document.getElementById('stat-dev').textContent = counts.dev;
+    document.getElementById('stat-transitive').textContent = counts.transitive;
+
+    // Setup interactions
+    setupClickDetection();
+    setupInstructions();
+}
+
+// --- Click Detection ---
+// The library emits nodeMouseDown, not nodeClick.
+// We track mousedown/mouseup to distinguish click from drag.
+
+let mouseDownState = null;
+let clickTimeout = null;
+
+function setupClickDetection() {
+    graph.on('nodeMouseDown', function (event) {
+        mouseDownState = {
+            nodeId: event.node.id,
+            nodeType: event.node.type,
+            x: event.position.x,
+            y: event.position.y,
+            time: Date.now()
+        };
+    });
+
+    document.addEventListener('mouseup', function (e) {
+        if (!mouseDownState) return;
+
+        const dx = e.clientX - mouseDownState.x;
+        const dy = e.clientY - mouseDownState.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const elapsed = Date.now() - mouseDownState.time;
+
+        if (dist < 8 && elapsed < 300) {
+            const captured = { ...mouseDownState };
+
+            // Delay to disambiguate from double-click
+            if (clickTimeout) clearTimeout(clickTimeout);
+            clickTimeout = setTimeout(function () {
+                handleNodeClick(captured.nodeId, captured.nodeType);
+                clickTimeout = null;
+            }, 250);
+        }
+
+        mouseDownState = null;
+    });
+
+    // Cancel pending click on double-click (built-in filtering takes over)
+    graph.on('nodeDoubleClick', function () {
+        if (clickTimeout) {
+            clearTimeout(clickTimeout);
+            clickTimeout = null;
+        }
+    });
+}
+
+// --- Path Tracing ---
+
+function handleNodeClick(nodeId, nodeType) {
+    if (vulnMode) return; // vuln overlay takes priority
+
+    graph.clearHighlights();
+
+    if (nodeId === ROOT_ID) {
+        showNodeInfoPanel(nodeId, nodeType);
+        return;
+    }
+
+    // Highlight path from root to clicked node (forward BFS direction)
+    const path = graph.highlightPath(ROOT_ID, nodeId, {
+        pathColor: '#22d3ee',
+        pathWidth: 3,
+        animate: true
+    });
+
+    showNodeInfoPanel(nodeId, nodeType);
+
+    if (path && path.length > 0) {
+        showStatus('Dependency chain: ' + path.join(' \u2192 '));
+    } else {
+        showStatus('No direct chain found from root to ' + nodeId);
+    }
+}
+
+// --- Vulnerability Overlay ---
+
+function toggleVulnerabilities() {
+    vulnMode = !vulnMode;
+    const btn = document.getElementById('vuln-toggle');
+
+    if (vulnMode) {
+        btn.classList.add('active');
+        btn.textContent = 'Hide Vulnerabilities';
+        graph.clearHighlights();
+        showVulnerabilities();
+    } else {
+        btn.classList.remove('active');
+        btn.textContent = 'Show Vulnerabilities';
+        clearVulnerabilities();
+    }
+}
+
+function showVulnerabilities() {
+    const vulnNodeIds = Object.keys(VULN_DATA);
+
+    // Highlight each vulnerable node's chain from root
+    vulnNodeIds.forEach(function (nodeId) {
+        const severity = VULN_DATA[nodeId].severity;
+        const color = severity === 'critical' ? '#ef4444' : '#f59e0b';
+
+        graph.highlightPath(ROOT_ID, nodeId, {
+            pathColor: color,
+            pathWidth: severity === 'critical' ? 4 : 3,
+            animate: true
+        });
+    });
+
+    showStatus(
+        'Showing ' +
+            vulnNodeIds.length +
+            ' known vulnerabilities — ' +
+            vulnNodeIds
+                .map(function (id) {
+                    return id + ' (' + VULN_DATA[id].severity + ')';
+                })
+                .join(', ')
+    );
+}
+
+function clearVulnerabilities() {
+    graph.clearHighlights();
+    hideStatus();
+}
+
+// --- Node Info Panel ---
+
+function showNodeInfoPanel(nodeId, nodeType) {
+    const info = document.getElementById('node-info');
+    document.getElementById('info-name').textContent = nodeId;
+
+    const typeLabels = {
+        root: 'Root package',
+        direct: 'Direct dependency',
+        dev: 'Dev dependency',
+        transitive: 'Transitive dependency'
+    };
+    document.getElementById('info-type').textContent = typeLabels[nodeType] || nodeType;
+
+    const vulnEl = document.getElementById('info-vuln');
+    if (VULN_DATA[nodeId]) {
+        const v = VULN_DATA[nodeId];
+        vulnEl.textContent = v.severity.toUpperCase() + ': ' + v.advisory;
+        vulnEl.className =
+            'node-info-vuln ' + (v.severity === 'critical' ? 'vuln-critical' : 'vuln-warning');
+        vulnEl.style.display = 'block';
+    } else {
+        vulnEl.style.display = 'none';
+    }
+
+    info.style.display = 'block';
+}
+
+// --- Status Bar ---
+
+function showStatus(msg) {
+    const bar = document.getElementById('status-bar');
+    bar.textContent = msg;
+    bar.style.display = 'block';
+}
+
+function hideStatus() {
+    document.getElementById('status-bar').style.display = 'none';
+}
+
+// --- Controls ---
+
+function clearAllHighlights() {
+    if (vulnMode) {
+        toggleVulnerabilities();
+    }
+    graph.clearHighlights();
+    document.getElementById('node-info').style.display = 'none';
+    hideStatus();
+}
+
+// --- Instruction Panel ---
+
+function setupInstructions() {
+    if (localStorage.getItem('npm-explorer-instructions-dismissed')) {
+        document.getElementById('instructions').style.display = 'none';
+    }
+}
+
+function dismissInstructions() {
+    document.getElementById('instructions').style.display = 'none';
+    localStorage.setItem('npm-explorer-instructions-dismissed', 'true');
+}
+
+// Expose for HTML
+window.initializeWhenReady = initializeWhenReady;
+window.graph = graph;
+window.toggleVulnerabilities = toggleVulnerabilities;
+window.clearAllHighlights = clearAllHighlights;
+window.dismissInstructions = dismissInstructions;

--- a/docs/examples/npm-explorer.js
+++ b/docs/examples/npm-explorer.js
@@ -282,6 +282,7 @@ function handleNodeClick(nodeId, nodeType) {
     if (vulnMode) return; // vuln overlay takes priority
 
     graph.clearHighlights();
+    restoreTypeStyles();
 
     if (nodeId === ROOT_ID) {
         showNodeInfoPanel(nodeId, nodeType);
@@ -351,7 +352,17 @@ function showVulnerabilities() {
 
 function clearVulnerabilities() {
     graph.clearHighlights();
+    // clearHighlights removes CSS classes but doesn't restore original colors,
+    // so re-apply type styles to reset node/edge appearance
+    restoreTypeStyles();
     hideStatus();
+}
+
+function restoreTypeStyles() {
+    graph.setNodeTypeStyle('root', { fill: '#8b5cf6', stroke: '#7c3aed', strokeWidth: 3 });
+    graph.setNodeTypeStyle('direct', { fill: '#3b82f6', stroke: '#2563eb', strokeWidth: 2 });
+    graph.setNodeTypeStyle('dev', { fill: '#f59e0b', stroke: '#d97706', strokeWidth: 2 });
+    graph.setNodeTypeStyle('transitive', { fill: '#6b7280', stroke: '#4b5563', strokeWidth: 1 });
 }
 
 // --- Node Info Panel ---
@@ -401,6 +412,7 @@ function clearAllHighlights() {
         toggleVulnerabilities();
     }
     graph.clearHighlights();
+    restoreTypeStyles();
     document.getElementById('node-info').style.display = 'none';
     hideStatus();
 }

--- a/docs/examples/npm-explorer.js
+++ b/docs/examples/npm-explorer.js
@@ -358,11 +358,36 @@ function clearVulnerabilities() {
     hideStatus();
 }
 
+// Re-apply original colors directly to SVG elements without recreating the DOM.
+// setNodeTypeStyle() triggers a full re-render which resets the camera.
+var TYPE_STYLES = {
+    root: { fill: '#8b5cf6', stroke: '#7c3aed', strokeWidth: '3' },
+    direct: { fill: '#3b82f6', stroke: '#2563eb', strokeWidth: '2' },
+    dev: { fill: '#f59e0b', stroke: '#d97706', strokeWidth: '2' },
+    transitive: { fill: '#6b7280', stroke: '#4b5563', strokeWidth: '1' }
+};
+
 function restoreTypeStyles() {
-    graph.setNodeTypeStyle('root', { fill: '#8b5cf6', stroke: '#7c3aed', strokeWidth: 3 });
-    graph.setNodeTypeStyle('direct', { fill: '#3b82f6', stroke: '#2563eb', strokeWidth: 2 });
-    graph.setNodeTypeStyle('dev', { fill: '#f59e0b', stroke: '#d97706', strokeWidth: 2 });
-    graph.setNodeTypeStyle('transitive', { fill: '#6b7280', stroke: '#4b5563', strokeWidth: 1 });
+    var data = buildDataset();
+    data.nodes.forEach(function (n) {
+        var style = TYPE_STYLES[n.type];
+        if (!style) return;
+        var el = document.querySelector('[data-id="' + n.id + '"]');
+        if (!el || !el.firstElementChild) return;
+        var shape = el.firstElementChild;
+        shape.setAttribute('fill', style.fill);
+        shape.setAttribute('stroke', style.stroke);
+        shape.setAttribute('stroke-width', style.strokeWidth);
+    });
+    // Also restore edge colors
+    var container = document.getElementById('graph-container');
+    if (container) {
+        var lines = container.querySelectorAll('line.link');
+        lines.forEach(function (line) {
+            line.removeAttribute('stroke');
+            line.removeAttribute('stroke-width');
+        });
+    }
 }
 
 // --- Node Info Panel ---

--- a/docs/examples/npm-explorer.js
+++ b/docs/examples/npm-explorer.js
@@ -237,8 +237,8 @@ let clickTimeout = null;
 function setupClickDetection() {
     graph.on('nodeMouseDown', function (event) {
         mouseDownState = {
-            nodeId: event.node.id,
-            nodeType: event.node.type,
+            nodeId: event.node.data.id,
+            nodeType: event.node.data.type,
             x: event.position.x,
             y: event.position.y,
             time: Date.now()

--- a/docs/examples/npm-explorer.js
+++ b/docs/examples/npm-explorer.js
@@ -312,12 +312,12 @@ function toggleVulnerabilities() {
 
     if (vulnMode) {
         btn.classList.add('active');
-        btn.textContent = 'Hide Vulnerabilities';
+        btn.textContent = 'Hide Known CVEs';
         graph.clearHighlights();
         showVulnerabilities();
     } else {
         btn.classList.remove('active');
-        btn.textContent = 'Show Vulnerabilities';
+        btn.textContent = 'Show Known CVEs';
         clearVulnerabilities();
     }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -741,6 +741,34 @@
 
                         <div
                             class="example-card fade-in"
+                            onclick="window.location.href='examples/npm-explorer.html'"
+                            style="cursor: pointer"
+                        >
+                            <div class="example-preview">
+                                <i class="fab fa-npm" style="font-size: 3rem"></i>
+                            </div>
+                            <div class="example-content">
+                                <h3 class="example-title">npm Dependency Explorer</h3>
+                                <p class="example-description">
+                                    Visualize npm package dependencies with path tracing,
+                                    vulnerability overlays, and interactive filtering. A real-world
+                                    showcase of directed graphs.
+                                </p>
+                                <div class="example-links">
+                                    <a
+                                        href="examples/npm-explorer.html"
+                                        class="btn btn-primary btn-small"
+                                        onclick="event.stopPropagation();"
+                                    >
+                                        <i class="fas fa-external-link-alt"></i>
+                                        View Demo
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            class="example-card fade-in"
                             onclick="window.location.href='examples/basic.html'"
                             style="cursor: pointer"
                         >
@@ -841,6 +869,7 @@
                 <div class="footer-section">
                     <h3>Examples</h3>
                     <ul>
+                        <li><a href="examples/npm-explorer.html">npm Dependency Explorer</a></li>
                         <li><a href="examples/dependency-graph.html">Module Dependencies</a></li>
                         <li><a href="examples/basic.html">Basic Network</a></li>
                         <li><a href="examples/advanced.html">Advanced Features</a></li>

--- a/docs/plans/2026-03-27-002-feat-npm-dependency-explorer-demo-plan.md
+++ b/docs/plans/2026-03-27-002-feat-npm-dependency-explorer-demo-plan.md
@@ -1,0 +1,220 @@
+---
+title: "feat: Add npm Dependency Explorer demo"
+type: feat
+status: completed
+date: 2026-03-27
+origin: docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md
+---
+
+# feat: Add npm Dependency Explorer Demo
+
+## Overview
+
+Create a polished demo page that visualizes an npm-style dependency graph, showcasing the SVGNet library's full feature set: directed edges, path highlighting, vulnerability overlays, depth filtering, node shapes, grouping, and theming. This is a "look what you can build" showcase aimed at potential library users.
+
+## Problem Statement / Motivation
+
+The library has three demos (basic, advanced diplomatic networks, internal module dependencies) but none showcase a universally relatable real-world use case. Every JS developer understands npm dependency graphs. This demo will demonstrate the library's capabilities in a context that immediately resonates with the target audience. (see origin: `docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md`)
+
+## Proposed Solution
+
+A single-page demo (`docs/examples/npm-explorer.html` + `npm-explorer.js`) with a curated ~40 node dataset modeled after an Express-like package ecosystem. Three interactive showcases: path tracing, vulnerability overlay, and depth filtering.
+
+**Note:** The filename `dependency-graph.html` is already taken (used for internal module dependency visualization). This demo uses `npm-explorer.html`.
+
+## Technical Considerations
+
+### Critical: Path Direction for `highlightPath`
+
+The library's `HighlightManager.findShortestPath()` uses BFS that only follows forward adjacency for directed edges (source → target). If edges are modeled as `dependent → dependency` (e.g., `express → body-parser`), then `highlightPath(body-parser, express)` will fail — BFS can't traverse backward.
+
+**Solution:** Call `highlightPath(rootId, transitiveDepId)` (forward direction from root to transitive dep). The visual result still shows the chain; arrowheads indicate dependency direction correctly.
+
+### Critical: Click Detection
+
+The library emits `nodeMouseDown`, not `nodeClick`. Path tracing requires distinguishing click from drag-start:
+- Track mousedown position and time
+- On mouseup, if same node, <200ms elapsed, <5px movement → treat as click
+- This is standard click detection and can be implemented in the demo JS
+
+### Important: Click vs Double-Click Disambiguation
+
+Single-click triggers path tracing (R5), double-click triggers depth filtering (R7, built-in behavior). These conflict on the same node.
+
+**Solution:** Delay path trace by 250ms after single click. If `nodeDoubleClick` fires within that window, cancel the path trace and let filtering proceed.
+
+### Important: Interaction State Machine
+
+Three visual states can overlap. State priority rules:
+
+| Current State | Action | Result |
+|---|---|---|
+| Normal | Click transitive dep | Path trace highlights |
+| Normal | Toggle vuln overlay | Vuln coloring applies |
+| Normal | Double-click node | Depth filter activates |
+| Path highlighted | Click another node | Replace path highlight |
+| Path highlighted | Click background | Clear highlights |
+| Path highlighted | Toggle vuln overlay | Clear path, apply vuln |
+| Path highlighted | Double-click node | Clear path, filter |
+| Vuln overlay active | Click node | No path trace (vuln mode takes priority) |
+| Vuln overlay active | Toggle vuln OFF | Restore normal coloring |
+| Vuln overlay active | Double-click node | Filter (vuln colors persist on visible nodes) |
+| Filtered | Click transitive dep | Path trace within filtered view |
+| Filtered | Toggle vuln overlay | Vuln colors on visible nodes |
+
+### Vulnerability Overlay Implementation
+
+`setNodeTypeStyle()` changes all nodes of a type — too coarse for per-node security status. Instead:
+- Use `highlightNeighbors()` or manual style application via DOM for individual node coloring
+- Mark 2-3 curated packages as "vulnerable" with upstream chains as attack paths
+- Use `highlightPath()` to show compromised dependency chains in red
+
+### Security
+
+Per institutional learnings: any user-supplied text in tooltips must be escaped via `escapeHtml()`. The curated dataset is hardcoded so risk is low, but maintain the pattern for consistency.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] **R1.** New demo at `docs/examples/npm-explorer.html` + `npm-explorer.js` loads and renders correctly
+- [ ] **R2.** Curated dataset of ~30-50 nodes with realistic npm package names and dependency relationships
+- [ ] **R3.** Nodes visually distinguished by type: root (circle, larger), direct deps (rectangle), dev deps (triangle), transitive deps (circle, smaller)
+- [ ] **R4.** All edges directed with arrowheads (`defaultDirected: true`)
+- [ ] **R5.** Path tracing: clicking a transitive dep highlights the full chain to root with animation
+- [ ] **R6.** Vulnerability overlay: toggle button recolors nodes by security status (green/amber/red) and highlights compromised chains
+- [ ] **R7.** Depth filtering: double-clicking any package filters to its neighborhood with breadcrumb navigation back
+- [ ] **R8.** Instruction panel on first load explaining the three interactive features, dismissible, with localStorage persistence
+- [ ] **R9.** Works with both light and dark themes
+
+### Quality Gates
+
+- [ ] Graph settles into a readable layout within 2-3 seconds
+- [ ] No console errors during normal interaction
+- [ ] Works in both `npm run dev` (localhost:8080) and production build (static files)
+- [ ] All three interactive features work without visual glitches or conflicts
+
+## Implementation Plan
+
+### Phase 1: Data and Structure
+
+**Files:** `docs/examples/npm-explorer.html`, `docs/examples/npm-explorer.js`
+
+1. Create `npm-explorer.html` following the established demo pattern:
+   - Standard meta tags, CSS link to `../assets/svgnet.css`
+   - Dynamic script loader (dev vs production detection)
+   - Layout: sidebar with stats/controls + main graph area (similar to existing `dependency-graph.html`)
+   - Instruction overlay panel (dismissible)
+   - Vulnerability toggle button in sidebar
+   - Stats section: total packages, direct deps, dev deps, transitive deps
+
+2. Create curated dataset in `npm-explorer.js` (inline, not external JSON):
+   - Root: `my-app` (type: "root", shape: circle, size: 50)
+   - ~8 direct deps: `express`, `lodash`, `axios`, `react`, `webpack`, `dotenv`, `cors`, `morgan`
+   - ~5 dev deps: `jest`, `eslint`, `prettier`, `typescript`, `nodemon`
+   - ~25 transitive deps: realistic sub-dependencies (e.g., express → `body-parser`, `cookie-parser`, `qs`, `debug`, `mime`; axios → `follow-redirects`; webpack → `tapable`, `enhanced-resolve`, `watchpack`)
+   - Vulnerability data: mark `qs` (critical), `debug` (warning) as vulnerable, with chains: `my-app → express → body-parser → qs` and `my-app → express → debug`
+
+3. Initialize `SVGNet` with:
+   ```javascript
+   new SVGNet('graph-container', {
+       data: { nodes, links },
+       config: {
+           title: 'npm Dependency Explorer',
+           theme: 'light',
+           showControls: true,
+           showLegend: true,
+           showBreadcrumbs: true,
+           defaultDirected: true,
+           filterDepth: 2
+       }
+   });
+   ```
+
+4. Set custom node type styles via `setNodeTypeStyle()` for root, direct, dev, transitive types
+
+### Phase 2: Interactive Features
+
+5. **Click detection layer** — implement mousedown/mouseup tracking to produce reliable click events from `nodeMouseDown`:
+   ```javascript
+   let pendingClick = null;
+   graph.on('nodeMouseDown', (event) => {
+       // Record mousedown state
+   });
+   document.addEventListener('mouseup', (event) => {
+       // If same node, <200ms, <5px → schedule click with 250ms delay
+       // If double-click fires within window → cancel pending click
+   });
+   ```
+
+6. **Path tracing (R5):**
+   - On click of a transitive dep node, call `highlightPath(rootId, clickedNodeId, { pathColor: '#ff6b6b', pathWidth: 4, animate: true })`
+   - Note: call with root as source, transitive as target (forward BFS direction)
+   - On click background or non-transitive node → `clearHighlights()`
+   - Clicking another transitive dep replaces the highlight
+
+7. **Vulnerability overlay (R6):**
+   - Toggle button in sidebar: "Show Vulnerabilities"
+   - When ON: apply CSS classes or direct SVG style changes to mark nodes by security status
+   - Use `highlightPath()` to show compromised chains in red
+   - When OFF: restore original type-based coloring
+   - Clears any active path highlights when toggled
+
+8. **Depth filtering (R7):**
+   - Built-in double-click behavior handles this automatically
+   - Add 250ms delay to path trace to avoid conflict with double-click
+   - Breadcrumbs are built-in via `showBreadcrumbs: true`
+
+### Phase 3: Polish
+
+9. **Instruction panel (R8):**
+   - Floating overlay on first load with three feature descriptions
+   - "Got it" button dismisses and stores in `localStorage`
+   - Key hints: "Click a package to trace its dependency chain", "Toggle vulnerabilities to see security risks", "Double-click to zoom into a package's neighborhood"
+
+10. **Theme support (R9):**
+    - Theme toggle is built-in
+    - Ensure custom vulnerability colors work in both light and dark themes
+    - Test instruction panel styling in both themes
+
+11. **Testing:**
+    - Test in `npm run dev` mode
+    - Test with `npm run build` + static file server
+    - Verify all three features work without conflicts
+    - Verify physics settle into readable layout
+
+## Scope Boundaries
+
+- No live npm registry API calls — fully curated data (see origin)
+- No "paste your package.json" functionality (see origin)
+- No actual vulnerability scanning — hand-assigned statuses (see origin)
+- No new library features required — uses only existing public API (see origin)
+- No changes to existing demos
+
+## Dependencies & Risks
+
+- **Risk:** Physics may not produce readable layout for 40+ nodes in 2-3s. Mitigation: tune physics params (increase damping, adjust repulsion) or seed initial positions.
+- **Risk:** Click vs drag discrimination may be finicky on touch devices. Mitigation: this demo targets desktop showcase; touch is a nice-to-have.
+- **Risk:** `nodeMouseDown` event may not provide sufficient data for click detection. Mitigation: verify event payload includes node ID and coordinates during Phase 2.
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md](docs/brainstorms/2026-03-27-npm-dependency-demo-requirements.md) — Key decisions: curated data over live API, Express-like ecosystem, three feature showcases (path tracing, vulnerability overlay, depth filtering).
+
+### Internal References
+
+- Existing demo pattern: `docs/examples/basic.html` + `basic.js`
+- Advanced demo with selection/highlighting: `docs/examples/advanced.js`
+- Existing dependency graph demo: `docs/examples/dependency-graph.html`
+- Public API: `src/index.ts`, `src/GraphNetwork.ts`
+- HighlightManager pathfinding: `src/highlighting/HighlightManager.ts:397-401`
+- Event system: `src/interaction/EventManager.ts:285`
+
+### Institutional Learnings
+
+- UMD global is `SVGNet`, use `createElement/appendChild` for script loading (never `document.write`)
+- Test demos against production build before declaring done
+- SVG canvas must use `position: absolute` for correct overlay positioning
+- Custom tooltip formatters must sanitize output via `escapeHtml()`

--- a/src/GraphNetwork.ts
+++ b/src/GraphNetwork.ts
@@ -543,51 +543,62 @@ export class GraphNetwork<T extends NodeData = NodeData> {
 
         // Run physics simulation (unless panning or cooled down)
         if (!this.events?.isPanning()) {
-            // When cooled down, only check every 30 frames (~2fps at 60fps)
+            // When cooled down, skip physics but still render every frame
+            // so that zoom/pan transforms remain smooth.
+            let skipPhysics = false;
             if (this.isPhysicsCooledDown) {
                 this.cooldownFrameSkip++;
                 if (this.cooldownFrameSkip < 30) {
-                    this.lastFrameTime = currentTime;
-                    this.animationFrame = requestAnimationFrame(() => this.animate());
-                    return;
+                    skipPhysics = true;
+                } else {
+                    this.cooldownFrameSkip = 0;
                 }
-                this.cooldownFrameSkip = 0;
             }
 
-            const physicsLinks = PhysicsEngine.createLinks(
-                this.links.map(link => ({
-                    source: link.source.getId(),
-                    target: link.target.getId(),
-                    weight: link.weight
-                })),
-                this.nodes
-            );
+            if (!skipPhysics) {
+                const physicsLinks = PhysicsEngine.createLinks(
+                    this.links.map(link => ({
+                        source: link.source.getId(),
+                        target: link.target.getId(),
+                        weight: link.weight
+                    })),
+                    this.nodes
+                );
 
-            let metrics;
-            if (this.layoutStrategy) {
-                metrics = this.layoutStrategy.tick(this.nodes, physicsLinks, this.filteredNodes);
-            } else {
-                metrics = this.physics.updateForces(this.nodes, physicsLinks, this.filteredNodes);
-                this.physics.updatePositions(this.nodes, this.filteredNodes);
-            }
-
-            // Check for equilibrium to enable cooldown
-            const isStable = this.layoutStrategy
-                ? this.layoutStrategy.isStable(metrics)
-                : this.physics.isInEquilibrium(metrics);
-            if (isStable) {
-                if (!this.isPhysicsCooledDown) {
-                    this.isPhysicsCooledDown = true;
-                    this.logger.debug('Physics reached equilibrium — entering cooldown');
+                let metrics;
+                if (this.layoutStrategy) {
+                    metrics = this.layoutStrategy.tick(
+                        this.nodes,
+                        physicsLinks,
+                        this.filteredNodes
+                    );
+                } else {
+                    metrics = this.physics.updateForces(
+                        this.nodes,
+                        physicsLinks,
+                        this.filteredNodes
+                    );
+                    this.physics.updatePositions(this.nodes, this.filteredNodes);
                 }
-            } else if (this.isPhysicsCooledDown) {
-                this.isPhysicsCooledDown = false;
-                this.cooldownFrameSkip = 0;
-                this.logger.debug('Physics exited equilibrium — resuming full simulation');
+
+                // Check for equilibrium to enable cooldown
+                const isStable = this.layoutStrategy
+                    ? this.layoutStrategy.isStable(metrics)
+                    : this.physics.isInEquilibrium(metrics);
+                if (isStable) {
+                    if (!this.isPhysicsCooledDown) {
+                        this.isPhysicsCooledDown = true;
+                        this.logger.debug('Physics reached equilibrium — entering cooldown');
+                    }
+                } else if (this.isPhysicsCooledDown) {
+                    this.isPhysicsCooledDown = false;
+                    this.cooldownFrameSkip = 0;
+                    this.logger.debug('Physics exited equilibrium — resuming full simulation');
+                }
             }
         }
 
-        // Render current state
+        // Always render so zoom/pan transforms stay smooth during cooldown
         this.renderer?.render(this.nodes, this.links, this.filteredNodes);
 
         this.lastFrameTime = currentTime;

--- a/src/GraphNetwork.ts
+++ b/src/GraphNetwork.ts
@@ -433,6 +433,25 @@ export class GraphNetwork<T extends NodeData = NodeData> {
     }
 
     /**
+     * Sync the highlight manager's graph adjacency structure for pathfinding.
+     * Must be called after any data change (setData, addNode, addLink, removeNode, removeLink).
+     */
+    private syncHighlightGraph(): void {
+        if (!this.highlightManager) return;
+
+        const defaultDirected = this.config.defaultDirected ?? true;
+        const nodeIds = Array.from(this.nodes.keys());
+        const edgeData = Array.from(this.edges.values()).map(e => ({
+            id: e.id!,
+            source: e.source,
+            target: e.target,
+            directed: e.directed ?? defaultDirected
+        }));
+
+        this.highlightManager.updateGraphStructure(nodeIds, edgeData);
+    }
+
+    /**
      * Update physics configuration and notify physics engine
      * @param key - Configuration key
      * @param value - New value
@@ -1040,6 +1059,8 @@ export class GraphNetwork<T extends NodeData = NodeData> {
 
             this.logger.debug(`Added node "${nodeData.name}" (${nodeData.id})`);
 
+            this.syncHighlightGraph();
+
             // Emit enhanced event
             this.emit('nodeAdded', {
                 node,
@@ -1128,6 +1149,8 @@ export class GraphNetwork<T extends NodeData = NodeData> {
                     `GraphNetwork: Deleted node "${nodeId}" and ${connectedLinks.length} connected edges`
                 );
             }
+
+            this.syncHighlightGraph();
 
             // Emit enhanced events
             this.emit('nodeRemoved', {
@@ -1285,6 +1308,8 @@ export class GraphNetwork<T extends NodeData = NodeData> {
                 );
             }
 
+            this.syncHighlightGraph();
+
             // Emit enhanced event
             this.emit('linkAdded', {
                 linkData: { ...edgeData },
@@ -1388,6 +1413,8 @@ export class GraphNetwork<T extends NodeData = NodeData> {
                 );
             }
 
+            this.syncHighlightGraph();
+
             // Emit enhanced event
             this.emit('linkRemoved', {
                 linkData: { ...edgeData },
@@ -1447,6 +1474,7 @@ export class GraphNetwork<T extends NodeData = NodeData> {
         }
 
         if (removed) {
+            this.syncHighlightGraph();
             this.emit('linkRemoved', {
                 linkData: { source: sourceId, target: targetId },
                 type: 'linkRemoved',
@@ -2157,6 +2185,9 @@ export class GraphNetwork<T extends NodeData = NodeData> {
                     groupingStrength: this.config.groupingStrength
                 });
             }
+
+            // Update highlight manager's graph structure for pathfinding
+            this.syncHighlightGraph();
 
             // Start animation if not already running
             if (!this.isAnimating) {

--- a/src/highlighting/HighlightManager.ts
+++ b/src/highlighting/HighlightManager.ts
@@ -546,19 +546,26 @@ export class HighlightManager implements IHighlightManager {
         type: 'node' | 'edge',
         style: HighlightStyle
     ): void {
-        const element = document.getElementById(`${type}-${elementId}`);
+        const element = document.querySelector(`[data-id="${elementId}"]`) as HTMLElement | null;
         if (!element) return;
+
+        // For nodes, the data-id is on the <g> group — target the shape child for fill/stroke.
+        // For edges, the data-id is on the <line> element itself.
+        const target =
+            type === 'node'
+                ? (element.firstElementChild as HTMLElement | null) || element
+                : element;
 
         // Apply highlight styles
         if (style.color) {
             if (type === 'node') {
-                element.setAttribute('fill', style.color);
+                target.setAttribute('fill', style.color);
             }
-            element.setAttribute('stroke', style.color);
+            target.setAttribute('stroke', style.color);
         }
 
         if (style.strokeWidth) {
-            element.setAttribute('stroke-width', String(style.strokeWidth));
+            target.setAttribute('stroke-width', String(style.strokeWidth));
         }
 
         if (style.opacity !== undefined) {
@@ -587,8 +594,8 @@ export class HighlightManager implements IHighlightManager {
     /**
      * Clear highlight from DOM element
      */
-    private clearElementHighlight(elementId: string, type: 'node' | 'edge'): void {
-        const element = document.getElementById(`${type}-${elementId}`);
+    private clearElementHighlight(elementId: string, _type: 'node' | 'edge'): void {
+        const element = document.querySelector(`[data-id="${elementId}"]`) as HTMLElement | null;
         if (!element) return;
 
         // Remove highlight classes

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -509,7 +509,7 @@ export class UIManager {
                 key: 'repulsionStrength',
                 label: 'Repulsion',
                 min: 0,
-                max: 20,
+                max: 30,
                 step: 0.5,
                 value: 13,
                 description: 'Node repulsion force'

--- a/src/ui/managers/UISettingsManager.ts
+++ b/src/ui/managers/UISettingsManager.ts
@@ -65,7 +65,7 @@ export class UISettingsManager {
             key: 'repulsionStrength',
             label: 'Repulsion',
             min: 0,
-            max: 20,
+            max: 30,
             step: 0.5,
             value: 13,
             description: 'Node repulsion force'

--- a/tests/unit/HighlightManager.test.ts
+++ b/tests/unit/HighlightManager.test.ts
@@ -5,21 +5,26 @@
 import { HighlightManager } from '../../src/highlighting/HighlightManager';
 import { HighlightEvent, HighlightStyle } from '../../src/types/styling';
 
-// Mock DOM elements and getElementById
+// Mock DOM elements and querySelector
 const mockElements = new Map<string, HTMLElement>();
 
-const originalGetElementById = document.getElementById;
+const originalQuerySelector = document.querySelector.bind(document);
 beforeAll(() => {
-    document.getElementById = jest.fn((id: string) => {
-        return mockElements.get(id) || null;
-    });
+    document.querySelector = jest.fn((selector: string) => {
+        // Parse data-id attribute selector: [data-id="value"]
+        const match = selector.match(/\[data-id="(.+?)"\]/);
+        if (match) {
+            return mockElements.get(match[1]) || null;
+        }
+        return originalQuerySelector(selector);
+    }) as any;
 });
 
 afterAll(() => {
-    document.getElementById = originalGetElementById;
+    document.querySelector = originalQuerySelector;
 });
 
-const createMockElement = (id: string): HTMLElement => {
+const createMockElement = (id: string, isNode = false): HTMLElement => {
     const element = {
         setAttribute: jest.fn(),
         removeAttribute: jest.fn(),
@@ -31,8 +36,18 @@ const createMockElement = (id: string): HTMLElement => {
             setProperty: jest.fn(),
             removeProperty: jest.fn(),
             strokeDashoffset: ''
-        }
+        },
+        firstElementChild: null as any
     } as any;
+
+    // For node groups, create a child shape element that receives fill/stroke
+    if (isNode) {
+        const shapeChild = {
+            setAttribute: jest.fn(),
+            removeAttribute: jest.fn()
+        } as any;
+        element.firstElementChild = shapeChild;
+    }
 
     mockElements.set(id, element);
     return element;
@@ -71,12 +86,12 @@ describe('HighlightManager', () => {
         // Setup graph structure
         highlightManager.updateGraphStructure(sampleNodes, sampleEdges);
 
-        // Create mock DOM elements
+        // Create mock DOM elements — keyed by data-id values
         sampleNodes.forEach(nodeId => {
-            createMockElement(`node-${nodeId}`);
+            createMockElement(nodeId, true);
         });
         sampleEdges.forEach(edge => {
-            createMockElement(`edge-${edge.id}`);
+            createMockElement(edge.id);
         });
     });
 
@@ -126,12 +141,13 @@ describe('HighlightManager', () => {
         });
 
         test('should apply default styles when none provided', () => {
-            const mockElement = mockElements.get('node-node1')!;
+            const mockElement = mockElements.get('node1')!;
+            const shapeChild = mockElement.firstElementChild;
 
             highlightManager.highlightNode('node1');
 
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke', '#3b82f6');
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke-width', '2');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke', '#3b82f6');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke-width', '2');
             expect(mockElement.setAttribute).toHaveBeenCalledWith('opacity', '1');
         });
     });
@@ -167,8 +183,9 @@ describe('HighlightManager', () => {
         });
 
         test('should apply path-specific styles', () => {
-            const mockNodeElement = mockElements.get('node-node1')!;
-            const mockEdgeElement = mockElements.get('edge-edge1')!;
+            const mockNodeElement = mockElements.get('node1')!;
+            const nodeShape = mockNodeElement.firstElementChild!;
+            const mockEdgeElement = mockElements.get('edge1')!;
 
             highlightManager.highlightPath('node1', 'node2', {
                 pathColor: '#00ff00',
@@ -176,7 +193,7 @@ describe('HighlightManager', () => {
                 showFlow: false
             });
 
-            expect(mockNodeElement.setAttribute).toHaveBeenCalledWith('stroke', '#00ff00');
+            expect(nodeShape.setAttribute).toHaveBeenCalledWith('stroke', '#00ff00');
             expect(mockEdgeElement.setAttribute).toHaveBeenCalledWith('stroke', '#00ff00');
             expect(mockEdgeElement.setAttribute).toHaveBeenCalledWith('stroke-width', '6'); // pathWidth + 1
         });
@@ -205,8 +222,8 @@ describe('HighlightManager', () => {
         });
 
         test('should apply depth-based styling', () => {
-            const mockNode2Element = mockElements.get('node-node2')!;
-            const mockNode3Element = mockElements.get('node-node3')!;
+            const mockNode2Element = mockElements.get('node2')!;
+            const mockNode3Element = mockElements.get('node3')!;
 
             highlightManager.highlightNeighbors('node1', {
                 depth: 2,
@@ -214,9 +231,15 @@ describe('HighlightManager', () => {
                 fadeByDistance: true
             });
 
-            // node2 is depth 1, node3 is depth 2
-            expect(mockNode2Element.setAttribute).toHaveBeenCalledWith('stroke', '#ff0000');
-            expect(mockNode3Element.setAttribute).toHaveBeenCalledWith('stroke', '#00ff00');
+            // node2 is depth 1, node3 is depth 2 — stroke is applied to firstElementChild
+            expect(mockNode2Element.firstElementChild!.setAttribute).toHaveBeenCalledWith(
+                'stroke',
+                '#ff0000'
+            );
+            expect(mockNode3Element.firstElementChild!.setAttribute).toHaveBeenCalledWith(
+                'stroke',
+                '#00ff00'
+            );
         });
 
         test('should include edge highlighting when requested', () => {
@@ -230,7 +253,7 @@ describe('HighlightManager', () => {
         });
 
         test('should handle fade by distance', () => {
-            const mockNode2Element = mockElements.get('node-node2')!;
+            const mockNode2Element = mockElements.get('node2')!;
 
             highlightManager.highlightNeighbors('node1', {
                 depth: 2,
@@ -260,20 +283,23 @@ describe('HighlightManager', () => {
         });
 
         test('should apply connection styles', () => {
-            const mockNodeElement = mockElements.get('node-node1')!;
-            const mockEdgeElement = mockElements.get('edge-edge1')!;
+            const mockNodeElement = mockElements.get('node1')!;
+            const mockEdgeElement = mockElements.get('edge1')!;
 
             const style: HighlightStyle = { color: '#ff00ff', strokeWidth: 4 };
             highlightManager.highlightConnections('node1', style);
 
-            expect(mockNodeElement.setAttribute).toHaveBeenCalledWith('stroke', '#ff00ff');
+            expect(mockNodeElement.firstElementChild!.setAttribute).toHaveBeenCalledWith(
+                'stroke',
+                '#ff00ff'
+            );
             expect(mockEdgeElement.setAttribute).toHaveBeenCalledWith('stroke', '#ff00ff');
         });
     });
 
     describe('Highlight Clearing', () => {
         test('should clear specific node highlight', () => {
-            const mockElement = mockElements.get('node-node1')!;
+            const mockElement = mockElements.get('node1')!;
             highlightManager.highlightNode('node1');
             mockCallback.mockClear();
 
@@ -320,7 +346,8 @@ describe('HighlightManager', () => {
 
     describe('DOM Interaction', () => {
         test('should apply highlight styles to DOM elements', () => {
-            const mockElement = mockElements.get('node-node1')!;
+            const mockElement = mockElements.get('node1')!;
+            const shapeChild = mockElement.firstElementChild!;
 
             highlightManager.highlightNode('node1', {
                 color: '#ff0000',
@@ -331,9 +358,9 @@ describe('HighlightManager', () => {
                 pulse: true
             });
 
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('fill', '#ff0000');
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke', '#ff0000');
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke-width', '5');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('fill', '#ff0000');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke', '#ff0000');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke-width', '5');
             expect(mockElement.setAttribute).toHaveBeenCalledWith('opacity', '0.8');
             expect(mockElement.classList.add).toHaveBeenCalledWith('graph-highlight-animated');
             expect(mockElement.classList.add).toHaveBeenCalledWith('graph-highlight-glow');
@@ -351,7 +378,7 @@ describe('HighlightManager', () => {
         });
 
         test('should set z-index via CSS custom property', () => {
-            const mockElement = mockElements.get('node-node1')!;
+            const mockElement = mockElements.get('node1')!;
 
             highlightManager.highlightNode('node1', { zIndex: 100 });
 
@@ -420,13 +447,14 @@ describe('HighlightManager', () => {
         });
 
         test('should merge styles with defaults', () => {
-            const mockElement = mockElements.get('node-node1')!;
+            const mockElement = mockElements.get('node1')!;
+            const shapeChild = mockElement.firstElementChild!;
 
             highlightManager.highlightNode('node1', { color: '#ff0000' });
 
             // Should apply custom color but use default values for other properties
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke', '#ff0000');
-            expect(mockElement.setAttribute).toHaveBeenCalledWith('stroke-width', '2'); // default
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke', '#ff0000');
+            expect(shapeChild.setAttribute).toHaveBeenCalledWith('stroke-width', '2'); // default
             expect(mockElement.setAttribute).toHaveBeenCalledWith('opacity', '1'); // default
         });
 


### PR DESCRIPTION
## Summary
- New demo page (`docs/examples/npm-explorer.html` + `npm-explorer.js`) showcasing SVGNet with a real-world npm dependency graph (~40 curated nodes)
- Three interactive features: click-to-trace dependency chains, "Show Known CVEs" vulnerability overlay, and double-click depth filtering
- **Library bugfix:** `highlightPath()`, `highlightNeighbors()`, and `highlightConnections()` were silently broken — `updateGraphStructure()` was never called so the adjacency map was always null
- **Library bugfix:** Highlight DOM targeting used `getElementById` with prefixed IDs that don't exist; fixed to use `querySelector('[data-id="..."]')` and target shape child elements for fill/stroke

## Test plan
- [ ] Run `npm run dev` and open `http://localhost:8080/examples/npm-explorer.html`
- [ ] Click any package node — dependency chain from root should highlight in cyan
- [ ] Click "Show Known CVEs" — vulnerable paths should highlight in red/amber
- [ ] Click "Hide Known CVEs" — colors should restore without camera zoom glitch
- [ ] Double-click any node — should filter to neighborhood with breadcrumb nav
- [ ] Verify existing demos (basic, advanced, dependency-graph) still work
- [ ] All 434 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)