### PR TITLE
chore: Slim CI matrix, bump Node engines, release v0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,14 @@ jobs:
     name: Test & Lint
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x, 22.x]
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '22.x'
         cache: 'npm'
 
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-27
+
+### Changed
+- CI test matrix reduced from Node 18/20/22 to Node 22.x only (faster CI)
+- Minimum Node.js engine bumped from >= 18.0.0 to >= 20.0.0 (Node 18 EOL)
+
 ## [0.4.0] - 2026-03-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svgnet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Modern SVG graph visualization library with advanced theming, mobile-first design, and customizable physics simulation. Features dynamic node/edge styling, touch optimization, and zero dependencies.",
   "type": "module",
   "main": "dist/SVGnet.cjs",
@@ -130,7 +130,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## Summary
- Drop Node 18/20 from CI test matrix — test on Node 22.x only (3x faster CI)
- Bump minimum Node.js engine from >= 18.0.0 to >= 20.0.0 (Node 18 EOL)
- Version bump to 0.4.1

## Test plan
- [x] Single Node 22.x CI job passes
- [x] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)